### PR TITLE
Output diff to raw logs

### DIFF
--- a/snapper.py
+++ b/snapper.py
@@ -605,6 +605,8 @@ def main():
 
         diff_data = get_diff()
 
+        log.info(diff_data)
+
         log.info(f'Diff output: {diff_data["equal"]} equal, ' +
                  f'{diff_data["added"]} added, ' +
                  f'{diff_data["removed"]} removed, ' +


### PR DESCRIPTION
Thanks for making this script, I switched from the bash version a few months ago and have been finding it a lot better.

I find that sometimes I need to look at what the diff was for a previous execution so I added this to output the full diff to the raw logs.