### PR TITLE
fix: parsing of snapraid zero sub-second timestamp status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ The reason I created this is that I wanted more granular control of how my setup
 
 I welcome bugfixes and contributions, but be aware that I will not merge PRs that I do not feel do not fit the usage of this tool.
 
-## How to use
+## Requirements
+- SnapRAID 12.2 or later
+- Python 3.7 or later
 
-- Ensure you have Python 3.7 or later installed
+## How to use
 - Install the necessary dependencies by running `pip3 install -r requirements.txt`
 - Download the [latest release](https://github.com/firasdib/snapper/releases/latest) of this project, or clone the git project.
 - Copy or rename `config.json.example` to `config.json`

--- a/snapper.py
+++ b/snapper.py
@@ -319,7 +319,7 @@ def get_status():
     error_count = re.search(r'^DANGER! In the array there are (?P<error_count>\d+) errors!',
                             snapraid_status, flags=re.MULTILINE)
     zero_subsecond_count = re.search(
-        r'^You have (?P<touch_files>\d+) files with zero sub-second timestamp', snapraid_status,
+        r'^You have (?P<touch_files>\d+) files with a zero sub-second timestamp', snapraid_status,
         flags=re.MULTILINE)
 
     sync_in_progress = bool(

--- a/snapper.py
+++ b/snapper.py
@@ -319,7 +319,7 @@ def get_status():
     error_count = re.search(r'^DANGER! In the array there are (?P<error_count>\d+) errors!',
                             snapraid_status, flags=re.MULTILINE)
     zero_subsecond_count = re.search(
-        r'^You have (?P<touch_files>\d+) files with a zero sub-second timestamp', snapraid_status,
+        r'^You have (?P<touch_files>\d+) files with (?:a )?zero sub-second timestamp', snapraid_status,
         flags=re.MULTILINE)
 
     sync_in_progress = bool(


### PR DESCRIPTION
Snapper was not running `snapraid touch` for me despite the presence of files with zero sub-second timestamps

This PR updates Snapper's regex to match the string output from Snapraid v12.3:

<img width="920" alt="image" src="https://github.com/firasdib/snapper/assets/17719/b98d88a8-9c80-4513-97df-e262ae97709c">