### PR TITLE
Add 'scrub_delayed_run' option to prevent scrub from executing every sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ config.json
 __pycache__
 /*.sh
 logs/
-snapper.scrubCount
+snapper.syncCount

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ config.json
 __pycache__
 /*.sh
 logs/
+snapper.scrubCount

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The reason I created this is that I wanted more granular control of how my setup
 - Allows you to run snapraid with a lower priority to keep server and drives responsive
 - Allows you to abort execution if configurable thresholds are broken
 - Allows you to `scrub` after `sync`
+- Allows delay of `scrub` job to every N invocations
 - Logs the raw snapraid output as well as formatted text
 - Creates a nicely formatted report and sends it via email or discord
 - Provides live insight into the sync/scrub process in Discord

--- a/config.json.example
+++ b/config.json.example
@@ -20,7 +20,8 @@
       "enabled": true,
       "check_percent": 3,
       "min_age": 30,
-      "scrub_new": true
+      "scrub_new": true,
+      "scrub_delayed_run": 0
     }
   },
   "notifications": {
@@ -48,5 +49,6 @@
   "scripts": {
     "pre_run": null,
     "post_run": null
-  }
+  },
+
 }

--- a/config.json.example
+++ b/config.json.example
@@ -49,6 +49,5 @@
   "scripts": {
     "pre_run": null,
     "post_run": null
-  },
-
+  }
 }

--- a/config.schema.json
+++ b/config.schema.json
@@ -137,6 +137,15 @@
                 true
               ],
               "description": "Whether to scrub newly synced blocks or not."
+            },
+            "scrub_delayed_run": {
+              "type": "number",
+              "examples": [
+                0,
+                3
+              ],
+              "description": "Number of script runs before running scrub. Use this if you don't want to scrub the array every time",
+              "minimum": 0
             }
           },
           "additionalProperties": false,

--- a/snapper.py
+++ b/snapper.py
@@ -33,6 +33,8 @@ with open(get_relative_path(__file__, './config.schema.json'), 'r') as f:
 
 validate(instance=config, schema=schema)
 
+scrub_count_file = get_relative_path(__file__, './snapper.scrubCount')
+
 
 #
 # Configure logging
@@ -484,13 +486,43 @@ def run_sync():
 
 
 def run_scrub():
-    enabled, scrub_new, check_percent, min_age = itemgetter(
-        'enabled', 'scrub_new', 'check_percent', 'min_age')(config['snapraid']['scrub'])
+    enabled, scrub_new, check_percent, min_age, scrub_delayed_run = itemgetter(
+        'enabled', 'scrub_new', 'check_percent', 'min_age', 'scrub_delayed_run'
+    )(config['snapraid']['scrub'])
 
     if not enabled:
         log.info('Scrubbing not enabled, skipping.')
 
         return None
+
+    if scrub_delayed_run and scrub_delayed_run > 0:
+        log.info('Delayed scrub is enabled.')
+
+        # get scrub_count from file or 0 if not exist or no number
+        try:
+            scrub_count = int(scrub_count_file.read_text().strip())
+        except (FileNotFoundError, ValueError):
+            scrub_count = 0
+
+        if scrub_count >= scrub_delayed_run:
+            # Run scrub job. If count is 0, scrub was forced externally
+            log.info(
+                f'Number of delayed runs has reached/exceeded threshold ({scrub_delayed_run}). A SCRUB job will run.'
+            )
+        else:
+            # DON'T run, increment count and skip the job
+            scrub_count += 1
+
+            # write the scrub_count to file here
+            scrub_count_file.write_text(str(scrub_count))
+
+            if scrub_count == scrub_delayed_run:
+                log.info('This is the **last** run left before running scrub job next time')
+            else:
+                log.info(
+                    f'{scrub_delayed_run - scrub_count} runs until the next scrub. **NOT** proceeding with SCRUB job.'
+                )
+            return None
 
     log.info('Running scrub job...')
 
@@ -515,6 +547,10 @@ def run_scrub():
 
     log.info(f'Scrub job finished, elapsed time {scrub_job_time}')
     notify_info(f'Scrub job finished, elapsed time **{scrub_job_time}**')
+
+    # reset the scrub counter
+    if os.path.exists(scrub_count_file):
+        os.remove(scrub_count_file)
 
     return scrub_job_time
 


### PR DESCRIPTION
Adds a configuration option similar to several other snapraid management scripts where you can specify only running the scrub job after N executions.
e.g. You run snapper every night, but you only want to scrub the array every 3 nights (to prevent unnecessary wear / runtimes, etc).

If the `scrub_delayed_run` option in the `scrub` section of the config file is set to a nonzero integer, snapper will wait that many runs between scrub jobs.

The `snapper.scrubCount` file is written to the system (next to the config file by default) and stores the number of times since a scrub job ran. If anyone knows of a better way to persist a value between script invocations, I would love to hear it.


Closes #12 